### PR TITLE
currentPosition variable bug fix

### DIFF
--- a/swipe-selector/src/main/java/com/roughike/swipeselector/SwipeAdapter.java
+++ b/swipe-selector/src/main/java/com/roughike/swipeselector/SwipeAdapter.java
@@ -144,6 +144,7 @@ class SwipeAdapter extends PagerAdapter implements View.OnClickListener, ViewPag
                     "not have an item at position " + position + ".");
         }
 
+        currentPosition = position; // AUTHOR FORGOT TO UPDATE THE CURRENT POSITION
         viewPager.setCurrentItem(position, animate);
     }
 
@@ -153,6 +154,7 @@ class SwipeAdapter extends PagerAdapter implements View.OnClickListener, ViewPag
         for (int i = 0; i < items.size(); i++) {
             if (items.get(i).getValue().equals(value)) {
                 viewPager.setCurrentItem(i, animate);
+                currentPosition = position; // AUTHOR FORGOT TO UPDATE THE CURRENT POSITION
                 itemExists = true;
                 break;
             }


### PR DESCRIPTION

The variable `"currentPosition"` needs to be updated when a SwipeItem programmmatically selected with `selectItemAt()` or `selectItemWithValue() `methods... so that `getSelectedItem()` method correctly retrieves the current selected item if it was selected programmatically.